### PR TITLE
Add a keep_error_code parameter

### DIFF
--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -59,11 +59,11 @@ func dataSource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			
+
 			"keep_error_code": {
 				Description: "An error code that tell the datasource to keep previous result unchanged",
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
 			},
 
 			"result": {
@@ -114,7 +114,7 @@ func dataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-				if keep_status_code == status.ExitStatus(){
+				if keep_status_code == status.ExitStatus() {
 					return nil
 				}
 			}

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"syscall"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -113,8 +114,8 @@ func dataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[TRACE] JSON output: %+v\n", string(resultJson))
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-				if keep_status_code == status.ExitStatus() {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				if keep_error_code == status.ExitStatus() {
 					return nil
 				}
 			}


### PR DESCRIPTION
When specified, the keep_error_code tell the data source that if the script return a specific error code, instead of throwing a Terraform error, it should end its execution and keep previous value.